### PR TITLE
Camera selector fix

### DIFF
--- a/Obscura/scripts/camera_selector.gd
+++ b/Obscura/scripts/camera_selector.gd
@@ -8,9 +8,9 @@ var current_controller:int = 0
 func _ready():
 	for camera in cameras:
 		if null != camera:
-			camera.current = false
+			camera.call_deferred("clear_current")
 	if(len(cameras) > current_controller+1):
-		cameras[current_controller].make_current()
+		cameras[current_controller].call_deferred("make_current")
 
 
 func _process(_delta):


### PR DESCRIPTION
Fixed an issue where the current camera when launching the game will be the first camera in the world node tree instead of the first camera in the camera array